### PR TITLE
Fix timer

### DIFF
--- a/math-boggle/TimeTracker.js
+++ b/math-boggle/TimeTracker.js
@@ -30,7 +30,7 @@ class TimeTracker extends React.Component {
     clearInterval(this.state.intervalID)
   }
   componentWillReceiveProps(nextProps){
-    if(nextProps.isPlaying){
+    if(nextProps.isPlaying && !this.props.isPlaying){
       this.setState({timeRemaining: this.props.totalTime})
       this.startCountdown()
     }


### PR DESCRIPTION
The timer was restarting every time it was getting passed any props. Now it only restarts if the game goes from inactive to active, which fixes the issue. 
