### PR TITLE
No repeating patterns

### DIFF
--- a/math-boggle/GameBoard.js
+++ b/math-boggle/GameBoard.js
@@ -10,12 +10,17 @@ class GameBoard extends React.Component {
       operationArray: [],
       correctAnswerArray: []
     }
+    this.allEquationsNumbers = []
+    this.usedPatterns = []
+    this.primes = [3,5,7,11,13,17,19,23,29,31]
+
     this.receiveClick = this.receiveClick.bind(this)
     this.findAnswer = this.findAnswer.bind(this)
     this.checkAnswer = this.checkAnswer.bind(this)
     this.resetOperation = this.resetOperation.bind(this)
     this.addToOperation = this.addToOperation.bind(this)
     this.findPower = this.findPower.bind(this)
+    this.uniqueAnswerCode = this.uniqueAnswerCode.bind(this)
   }
   receiveClick(buttonClicked){
 
@@ -26,6 +31,10 @@ class GameBoard extends React.Component {
     if(buttonClicked == "wrong"){
       this.resetOperation()
       return
+    }
+
+    if(Number.isInteger(buttonClicked)){
+      this.allEquationsNumbers.push(buttonClicked)
     }
 
     if(this.state.correctAnswerArray.length > 0){
@@ -39,6 +48,16 @@ class GameBoard extends React.Component {
       var newCorrectAnswerArray = this.state.correctAnswerArray
       newCorrectAnswerArray.shift()
       if(newCorrectAnswerArray.length == 0){
+
+        //check to see if this is a repeated pattern
+        var uniqueCode = this.uniqueAnswerCode()
+        if(this.usedPatterns.indexOf(uniqueCode) > -1){
+          this.resetOperation()
+          return
+        }
+
+        this.usedPatterns.push(uniqueCode)
+
         console.log("Correct answer!!!")
         var points = 1
         this.props.addToScore(points)
@@ -53,6 +72,15 @@ class GameBoard extends React.Component {
       this.resetOperation()
     }
   }
+
+  uniqueAnswerCode(){
+    var uniqueCode = 1;
+    for (var i = 0; i < this.allEquationsNumbers.length; i++) {
+      uniqueCode *= this.primes[this.allEquationsNumbers[i]]
+    };
+    return uniqueCode
+  }
+
   addToOperation(buttonClicked){
     switch(buttonClicked){
       case "=":
@@ -70,9 +98,6 @@ class GameBoard extends React.Component {
     while(joinedEquation.indexOf("^") > -1){
       joinedEquation = this.findPower(joinedEquation)
     }
-
-
-    console.log("joined:", joinedEquation)
 
     //To do: check to make sure it's a valid equation. Ex: 15=15 or 1203*0=0 are not acceptable
     var correctAnswer = eval(joinedEquation)
@@ -96,9 +121,11 @@ class GameBoard extends React.Component {
       operationArray: [],
       correctAnswerArray: []
     })
+    this.allEquationsNumbers = []
   }
   componentWillReceiveProps(nextProps){
     if(!nextProps.isPlaying){
+      this.usedPatterns = []
       this.resetOperation()
     }
   }


### PR DESCRIPTION
Just like Boggle, I didn't want the user to be able to repeat a pattern. With math I also didn't want reversed versions of the same pattern. For example, if the user does `4+6=10`, I don't want them to be able to do `10-6=4` or `10-4=6`. I wanted to make sure that this restriction would work whether or not the user clicked the same pattern of blocks. 

The solution - every number combination will have a unique semi-prime(ish) number. To find this unique number, I keep track of every number in the equation. I give each number 0 - 9 a prime number equivalent. Once the equation is done, I multiply all of the prime numbers. Ex: 

Equation: `2+2=4`
The prime number associated with 2 = `5`
The prime number associated with 4 = `9`
The unique number for this equation is `5*5*9` which equals 225. 

Any equation that has the numbers 2,2, and 4 will have a unique number of 225. All I need to do is keep track of 225 to see if that number combo has been run previously. 
